### PR TITLE
WSAS-7982 - fix geocoding accuracy

### DIFF
--- a/lib/cloudgeo.rb
+++ b/lib/cloudgeo.rb
@@ -54,9 +54,17 @@ class Cloudgeo
           return data
         end
 
-        if ((data[:quality] >= 0.6 && address.include?(data.dig(:address_components, :postal_code))) ||
-          (data[:quality] > 0.6 && data[:address].to_s.downcase.include?(' canada')))
-
+        if (
+          (
+            data[:quality] >= 0.6 &&
+            address.include?(data.dig(:address_components, :postal_code)) &&
+            address.include?(data.dig(:address_components, :street))
+          ) ||
+          (
+            data[:quality] > 0.6 &&
+            data[:address].to_s.downcase.include?(' canada')
+          )
+        )
           return data
         end
       else


### PR DESCRIPTION
What:
We use Geocodio and Google as geocoding services on Forge. While Geocodio offers a significantly lower cost, its results often lack the accuracy provided by Google. To address this, we attempt to match the address component of the data returned by our initial query with Geocodio’s results. However, relying strictly on quality scores and postal code matching is insufficient, as there are discrepancies in geocoded addresses even within the same postal code.

Ticket: https://pr-corpnet.atlassian.net/browse/WSAS-7982