### PR TITLE
Fix Mapbox accuracy check

### DIFF
--- a/lib/cloudgeo.rb
+++ b/lib/cloudgeo.rb
@@ -104,6 +104,8 @@ private
       data[:quality] >= 0.6 &&
       address.include?(data.dig(:address_components, :postal_code)) &&
       address.downcase.include?(data.dig(:address_components, :street).downcase)
+    when :mapbox
+      data[:quality] >= 0.6
     else
       data[:quality] >= 0.6 &&
       address.include?(data.dig(:address_components, :postal_code))

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 class Cloudgeo
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
Mapbox address geocode may exclude postal code which will cause an error or provide a false check